### PR TITLE
Add persistent weights for Connect Four

### DIFF
--- a/scripts/play_connect_four.py
+++ b/scripts/play_connect_four.py
@@ -1,8 +1,12 @@
+import os
 import numpy as np
 import torch
 from alphazero.connect_four import ConnectFour
 from alphazero.net import ResNet
 from alphazero.mcts import MCTS
+
+
+WEIGHTS_PATH = "connect_four_weights.pt"
 
 
 def main():
@@ -18,6 +22,8 @@ def main():
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = ResNet(game, num_res_blocks=9, num_hidden=128, device=device)
+    if os.path.exists(WEIGHTS_PATH):
+        model.load_state_dict(torch.load(WEIGHTS_PATH, map_location=device))
     model.eval()
     mcts = MCTS(game, args, model)
 

--- a/scripts/train_connect_four.py
+++ b/scripts/train_connect_four.py
@@ -1,13 +1,19 @@
+import os
 import torch
 from alphazero.connect_four import ConnectFour
 from alphazero.net import ResNet
 from alphazero.alpha_zero import AlphaZero
 
 
+WEIGHTS_PATH = "connect_four_weights.pt"
+
+
 def main():
     game = ConnectFour()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = ResNet(game, num_res_blocks=9, num_hidden=128, device=device)
+    if os.path.exists(WEIGHTS_PATH):
+        model.load_state_dict(torch.load(WEIGHTS_PATH, map_location=device))
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001, weight_decay=0.0001)
 
     args = {
@@ -25,6 +31,7 @@ def main():
 
     alpha_zero = AlphaZero(model, optimizer, game, args)
     alpha_zero.learn()
+    torch.save(model.state_dict(), WEIGHTS_PATH)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load weights if they exist when training
- save updated weights after training
- use stored weights when playing

## Testing
- `python -m py_compile scripts/train_connect_four.py scripts/play_connect_four.py alphazero/*.py`